### PR TITLE
Support `async-std` in cluster_async module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ test:
 	@REDISRS_SERVER_TYPE=unix cargo test -p redis --all-features -- --skip test_cluster --skip test_async_cluster --skip test_module
 
 	@echo "===================================================================="
+	@echo "Testing async-std"
+	@echo "===================================================================="
+	@REDISRS_SERVER_TYPE=tcp+tls cargo test -p redis --features=async-std-tls-comp,cluster-async -- --nocapture --test-threads=1
+
+	@echo "===================================================================="
 	@echo "Testing redis-test"
 	@echo "===================================================================="
 	@cargo test -p redis-test 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -83,7 +83,7 @@ tokio-comp = ["aio", "tokio", "tokio/net"]
 tokio-native-tls-comp = ["tls", "tokio-native-tls"]
 connection-manager = ["arc-swap", "futures", "aio"]
 streams = []
-cluster-async = ["cluster", "futures", "futures-util", "tokio/time", "log"]
+cluster-async = ["cluster", "futures", "futures-util", "log"]
 
 [dev-dependencies]
 rand = "0.8"

--- a/redis/src/aio.rs
+++ b/redis/src/aio.rs
@@ -19,9 +19,6 @@ use ::tokio::{
     sync::{mpsc, oneshot},
 };
 
-#[cfg(feature = "tls")]
-use native_tls::TlsConnector;
-
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]
 use tokio_util::codec::Decoder;
 

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -16,7 +16,7 @@ use tokio::{
 };
 
 #[cfg(feature = "tls")]
-use super::TlsConnector;
+use native_tls::TlsConnector;
 
 #[cfg(feature = "tokio-native-tls-comp")]
 use tokio_native_tls::TlsStream;

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -72,6 +72,9 @@ use crate::{
     parse_redis_url, Cmd, ConnectionAddr, ConnectionInfo, ErrorKind, IntoConnectionInfo,
     RedisError, RedisFuture, RedisResult, Value,
 };
+
+#[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+use crate::aio::{async_std::AsyncStd, RedisRuntime};
 use futures::{
     future::{self, BoxFuture},
     prelude::*,
@@ -156,13 +159,16 @@ where
     ) -> RedisResult<Connection<C>> {
         Pipeline::new(initial_nodes, retries).await.map(|pipeline| {
             let (tx, mut rx) = mpsc::channel::<Message<_>>(100);
-
-            tokio::spawn(async move {
+            let stream = async move {
                 let _ = stream::poll_fn(move |cx| rx.poll_recv(cx))
                     .map(Ok)
                     .forward(pipeline)
                     .await;
-            });
+            };
+            #[cfg(feature = "tokio-comp")]
+            tokio::spawn(stream);
+            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+            AsyncStd::spawn(stream);
 
             Connection(tx)
         })
@@ -289,7 +295,7 @@ pin_project! {
         },
         Sleep {
             #[pin]
-            sleep: tokio::time::Sleep,
+            sleep: BoxFuture<'static, ()>,
         },
     }
 }
@@ -381,7 +387,11 @@ where
                             Duration::from_millis(2u64.pow(request.retry.clamp(7, 16)) * 10);
                         request.info.excludes.clear();
                         this.future.set(RequestState::Sleep {
-                            sleep: tokio::time::sleep(sleep_duration),
+                            #[cfg(feature = "tokio-comp")]
+                            sleep: Box::pin(tokio::time::sleep(sleep_duration)),
+
+                            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+                            sleep: Box::pin(async_std::task::sleep(sleep_duration)),
                         });
                         return self.poll(cx);
                     }
@@ -964,7 +974,12 @@ impl Connect for MultiplexedConnection {
         async move {
             let connection_info = info.into_connection_info()?;
             let client = crate::Client::open(connection_info)?;
-            client.get_multiplexed_tokio_connection().await
+
+            #[cfg(feature = "tokio-comp")]
+            return client.get_multiplexed_tokio_connection().await;
+
+            #[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+            return client.get_multiplexed_async_std_connection().await;
         }
         .boxed()
     }

--- a/redis/tests/test_cluster_async.rs
+++ b/redis/tests/test_cluster_async.rs
@@ -289,3 +289,27 @@ fn test_async_cluster_error_in_inner_connection() {
     })
     .unwrap();
 }
+
+#[test]
+#[cfg(all(not(feature = "tokio-comp"), feature = "async-std-comp"))]
+fn test_async_cluster_async_std_basic_cmd() {
+    let cluster = TestClusterContext::new(3, 0);
+
+    block_on_all_using_async_std(async {
+        let mut connection = cluster.async_connection().await;
+        redis::cmd("SET")
+            .arg("test")
+            .arg("test_data")
+            .query_async(&mut connection)
+            .await?;
+        redis::cmd("GET")
+            .arg("test")
+            .clone()
+            .query_async(&mut connection)
+            .map_ok(|res: String| {
+                assert_eq!(res, "test_data");
+            })
+            .await
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Furthermore, add additional test run that ensures
async-std tests pass when no tokio features are
enabled.